### PR TITLE
Fix popups by always sending cookies

### DIFF
--- a/resources/scripts/custom.js
+++ b/resources/scripts/custom.js
@@ -53,7 +53,7 @@ $(function () {
 					'X-SMF-AJAX': 1
 				},
 				xhrFields: {
-					withCredentials: typeof allow_xhjr_credentials !== "undefined" ? allow_xhjr_credentials : false
+					withCredentials: true
 				},
 				type: "GET",
 				dataType: "html",


### PR DESCRIPTION
This sent me down a hours long rabbit hole where I changed every cookie setting, adding/removing CORS domains and headers, disabling Frame Security Options, and even reading [RFC 2606](https://datatracker.ietf.org/doc/html/rfc2606) and changing my development domain from forum.smf.local to forum.smf.test.

There is absolutely no use case where doing ajax to SMF and not sending cookies, since SMF will always redirect us to the login page anyway.